### PR TITLE
Add compilation status message to hot runtime.

### DIFF
--- a/src/lib/runtime/common.js
+++ b/src/lib/runtime/common.js
@@ -15,6 +15,15 @@ export default ({reload}) => {
   // things they are interested in.
   ipc.emit('watch', __webpack_dev_token__);
 
+  ipc.on('compile', ({token}) => {
+    // Ignore everything but the update we want. Other stats may end up
+    // getting sent to this app for other reasons.
+    if (token !== __webpack_dev_token__) {
+      return;
+    }
+    console.log('🔥  Compilation in progress.');
+  });
+
   ipc.on('stats', (stats) => {
     // Ignore everything but the update we want. Other stats may end up
     // getting sent to this app for other reasons.


### PR DESCRIPTION
Sometimes you'd like to know that your modules are actually recompiling – timely user feedback ensures users don't go and refresh the page or restart the app when they should just pause for a moment.

/cc @nealgranger 