### PR TITLE
Remove unused packages and support `webpack@2`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "purdy": "^1.6.0",
     "socket.io": "^1.3.7",
     "socket.io-client": "^1.3.7",
-    "strip-ansi": "^3.0.0",
-    "webpack": "^1.12.2",
-    "webpack-dev-middleware": "^1.2.0",
     "yargs": "^3.24.0"
   },
   "devDependencies": {
@@ -40,6 +37,10 @@
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-lodash-fp": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1"
+    "eslint-plugin-react": "^5.1.1",
+    "webpack": "2.1.0-beta.25"
+  },
+  "peerDependencies": {
+    "webpack": "^1.12.2 || ^2.1.0-beta.25"
   }
 }

--- a/src/lib/compiler.js
+++ b/src/lib/compiler.js
@@ -18,6 +18,7 @@ const options = {
     colors: true,
     modules: false,
     chunks: false,
+    children: false,
   },
 };
 
@@ -49,7 +50,10 @@ if (!config.output.publicPath) {
   config.output.publicPath += '/';
 }
 
-config.token = token;
+Object.defineProperty(config, 'token', {
+  value: token,
+  enumerable: false,
+});
 config.plugins.push(new webpack.DefinePlugin({
   __webpack_dev_token__: JSON.stringify(token), // eslint-disable-line
   'process.env.IPC_URL': JSON.stringify(process.env.IPC_URL),

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,6 @@
     "socket.io-client": "^1.3.7",
     "webpack": "^1.12.2",
     "webpack-config-babel": "^0.2.0",
-    "webpack-config-source-maps": "^0.2.2",
-    "webpack-partial": "^1.3.0"
+    "webpack-config-source-maps": "^0.2.2"
   }
 }


### PR DESCRIPTION
The only real change here is to define `token` as a non-enumerable property so it escapes webpack's "object cleaning". Some unused packages have been removed, and child compiler data is no longer logged (since it's huge when using CSS modules).

`webpack` is now part of `peerDependencies` so you can bring your own.

/cc @nealgranger 