### PR TITLE
Use `midori` instead of `http-middleware-metalab`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ TODO: Write example.
 
 [webpack]: https://webpack.github.io/
 [dev-server]: https://webpack.github.io/docs/webpack-dev-server.html
-[http-middleware]: https://github.com/metalabdesign/http-middleware-metalab
+[http-middleware]: https://github.com/metalabdesign/midori

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-lodash-fp": "^1.2.0",
     "eslint-plugin-react": "^5.1.1",
-    "webpack": "2.1.0-beta.25"
+    "webpack": "2.2.1"
   },
   "peerDependencies": {
-    "webpack": "^1.12.2 || ^2.1.0-beta.25"
+    "webpack": "^1.12.2 || ^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   "dependencies": {
     "backo": "^1.1.0",
     "chokidar": "^1.4.2",
-    "http-middleware-metalab": "^0.3.1",
     "interpret": "^0.6.6",
     "lodash": "^4.1.0",
     "memory-fs": "^0.3.0",
+    "midori": "^0.3.5",
+    "mime-types": "^2.1.14",
     "open": "^0.0.5",
     "purdy": "^1.6.0",
     "socket.io": "^1.3.7",

--- a/src/lib/platform/web.js
+++ b/src/lib/platform/web.js
@@ -2,17 +2,16 @@ import http from 'http';
 import ipc from '../ipc';
 import compose from 'lodash/flowRight';
 import identity from 'lodash/identity';
+import keyBy from 'lodash/fp/keyBy';
 import path from 'path';
-
-import thunk from 'http-middleware-metalab/middleware/thunk';
-
-import {asset} from 'http-middleware-metalab/middleware/assets';
-import send from 'http-middleware-metalab/middleware/send';
-import status from 'http-middleware-metalab/middleware/status';
-import match from 'http-middleware-metalab/middleware/match';
-import serve from 'http-middleware-metalab/middleware/serve';
-import verbs from 'http-middleware-metalab/middleware/match/verbs';
-import connect from 'http-middleware-metalab/adapter/http';
+import {lookup} from 'mime-types';
+import thunk from 'midori/thunk';
+import send from 'midori/send';
+import status from 'midori/status';
+import match from 'midori/match';
+import serve from 'midori/serve';
+import verbs from 'midori/match/verbs';
+import connect from 'midori/connect';
 
 import MemoryFileSystem from 'memory-fs';
 
@@ -26,6 +25,8 @@ export default (compiler) => {
   if (!compiler.options.output.publicPath) {
     compiler.options.output.publicPath = Math.random().toString(36).substr(2);
   }
+  
+  const publicPath = compiler.options.output.publicPath;
 
   const server = http.createServer();
   const index = 'index.html';
@@ -33,39 +34,41 @@ export default (compiler) => {
     thunk((app) => {
       let result = app;
       compiler.plugin('done', (stats) => {
-        result = match(asset(stats.toJson(), {index}), (app) => {
-          return {
-            ...app,
-            request(req, res) {
-              const file = path.join(compiler.outputPath, req.asset.name);
+        const address = server.address();
+        ipc.emit('proxy', {
+          url: `http://localhost:${address.port}${publicPath}`,
+          path: publicPath,
+          token: compiler.options.token,
+        });
+        const data = stats.toJson();
+        const index = keyBy('name', data.assets);
+        result = {
+          ...app,
+          request(req, res) {
+            const b = req.url.substr(data.publicPath.length);
+            const file = path.join(compiler.outputPath, b);
+            if (fs.existsSync(file)) {
               const data = fs.readFileSync(file);
               res.statusCode = 200;
-              res.setHeader('Content-Type', req.asset.contentType);
+              res.setHeader('Content-Type', lookup(b));
               res.setHeader('Content-Length', data.length);
               res.end(data);
-            },
-          };
-        })(app);
+            } else {
+              app.request(req, res);
+            }
+          },
+        };
       });
       return () => result;
     }),
     compiler.options.serve ? verbs.get(
-      compiler.options.output.publicPath,
+      publicPath,
       serve({
         root: compiler.options.serve,
       })
     ) : identity,
-    compose(send(), status(404))
+    compose(status(404), send())
   )({request() {}, error() {}});
-
-  server.on('listening', () => {
-    const address = server.address();
-    const path = compiler.options.output.publicPath;
-    ipc.emit('proxy', {
-      url: `http://localhost:${address.port}${path}`,
-      token: compiler.options.token,
-    });
-  });
 
   connect(app, server).listen();
 };

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -8,16 +8,16 @@ import url from 'url';
 import compose from 'lodash/flowRight';
 import matches from 'lodash/matches';
 import reject from 'lodash/reject';
-import send from 'http-middleware-metalab/middleware/send';
-import status from 'http-middleware-metalab/middleware/status';
-import proxy from 'http-middleware-metalab/middleware/proxy';
-import connect from 'http-middleware-metalab/adapter/http';
-import match from 'http-middleware-metalab/middleware/match';
-import path from 'http-middleware-metalab/middleware/match/path';
-import thunk from 'http-middleware-metalab/middleware/thunk';
-import serve from 'http-middleware-metalab/middleware/serve';
-import header from 'http-middleware-metalab/middleware/header';
-import verbs from 'http-middleware-metalab/middleware/match/verbs';
+import send from 'midori/send';
+import status from 'midori/status';
+import proxy from 'midori/proxy';
+import connect from 'midori/connect';
+import match from 'midori/match';
+import path from 'midori/match/path';
+import thunk from 'midori/thunk';
+import serve from 'midori/serve';
+import header from 'midori/header';
+import verbs from 'midori/match/verbs';
 
 import {kill, updateStats} from './util';
 


### PR DESCRIPTION
The same thing but using the properly named framework. Since the `webpack`-related utilities are not present in `midori`, the equivalent has been added to this repo instead. This also possibly fixes a bug whereby hot assets were not being sent down properly.

/cc @10xjs 