### PR TITLE
Hold connections open until `webpack` processes are done.

### DIFF
--- a/src/lib/platform/node.js
+++ b/src/lib/platform/node.js
@@ -2,11 +2,17 @@ import {fork} from 'child_process';
 import Backoff from 'backo';
 import path from 'path';
 import {kill as _kill} from '../util';
+import ipc from '../ipc';
 
 export default (compiler) => {
   if (compiler.options.target !== 'node') {
     return null;
   }
+  
+  ipc.emit('proxy', {
+    path: compiler.options.output.publicPath,
+    token: compiler.options.token,
+  });
 
   const backoff = new Backoff({min: 0, max: 1000 * 5});
   let child = null;

--- a/src/lib/platform/web.js
+++ b/src/lib/platform/web.js
@@ -27,6 +27,13 @@ export default (compiler) => {
   }
   
   const publicPath = compiler.options.output.publicPath;
+  
+  compiler.plugin('compile', () => {
+    ipc.emit('proxy', {
+      path: publicPath,
+      token: compiler.options.token,
+    });
+  });
 
   const server = http.createServer();
   const index = 'index.html';

--- a/src/lib/runtime/dev-server.js
+++ b/src/lib/runtime/dev-server.js
@@ -13,6 +13,7 @@ http.Server.prototype.listen = function() {
     const path = __webpack_public_path__ || '/'; // eslint-disable-line
     ipc.emit('proxy', {
       url: `http://localhost:${address.port}${path}`,
+      path,
       token: __webpack_dev_token__, // eslint-disable-line
     });
   });


### PR DESCRIPTION
Previously if you had stuff in flight the dev server would display its status page. Sometimes this can be frustrating and you would rather just have the browser wait until the page is ready and then load that. This is now the case. Unfortunately this kind of messes with `404` handling - to do `404` handling properly we need either timeouts or to still allow for a window of "blankness" where we have to wait until the server registers pages which are meant to be proxied. Either way this seems like a good start.

/cc @10xjs 