### PR TITLE
Update eslint and babel dependencies 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
   "presets": [
-    "metalab"
+    ["metalab", {
+      "targets": {
+        "node": 4,
+      },
+    }]
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - 6
   - 5
   - 4
-  - 0.12

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-core": "^6.13.2",
-    "babel-preset-metalab": "^0.2.0",
-    "eslint": "^2.10.2",
-    "eslint-config-metalab": "^4.0.1",
-    "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-lodash-fp": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1",
+    "babel-preset-metalab": "^1.0.0",
+    "eslint": "^3.5.0",
+    "eslint-config-metalab": "^6.0.1",
+    "eslint-plugin-filenames": "^1.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-lodash-fp": "^2.1.3",
+    "eslint-plugin-babel": "^4.1.1",
+    "eslint-plugin-react": "^6.10.0",
     "webpack": "2.2.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updated Eslint and Babel Dependencies occasioned by upgrades in babel-preset-metalab and eslint-config-metalab. 

Removed Node v.0.12 from Travis test, babel-preset-metalab no longer supports this version of node.