### PR TITLE
Really kill child processes when dying.

### DIFF
--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -23,7 +23,7 @@ import matches from 'lodash/matches';
 import reject from 'lodash/reject';
 import unionBy from 'lodash/fp/unionBy';
 
-import {kill, updateStats} from './util';
+import {killOnExit, kill, updateStats} from './util';
 
 const xx = () => get('/__webpack_udev', serve({
   root: join(
@@ -253,6 +253,7 @@ export default class Server extends http.Server {
         IPC_URL: `http://localhost:${address.port}/`,
       },
     });
+    killOnExit(compiler);
     return compiler;
   }
 

--- a/src/lib/platform/node.js
+++ b/src/lib/platform/node.js
@@ -2,7 +2,7 @@
 import {fork} from 'child_process';
 import Backoff from 'backo';
 import path from 'path';
-import {kill as _kill} from '../util';
+import {kill as _kill, killOnExit} from '../util';
 import ipc from '../ipc';
 
 export default (compiler) => {
@@ -74,8 +74,12 @@ export default (compiler) => {
 
   process.once('beforeExit', () => {
     rip = true;
-    kill();
   });
+  process.once('exit', () => {
+    rip = true;
+  });
+
+  killOnExit(child);
 
   compiler.plugin('done', (_stats) => {
     stats = _stats.toJson();

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -5,6 +5,9 @@ import flow from 'lodash/fp/flow';
 import sortBy from 'lodash/fp/sortBy';
 
 export const kill = (child, cb = () => {}) => {
+  if (child.killed) {
+    return;
+  }
   let timeout = null;
   child.once('exit', () => {
     if (timeout) {
@@ -29,4 +32,15 @@ export const updateStats = (previous, next) => {
     ...next,
     assets: sortBy('name', [...oldAssets, ...next.assets]),
   };
+};
+
+export const killOnExit = (child) => {
+  process.once('exit', () => {
+    if (!child.killed) {
+      child.kill('SIGTERM');
+    }
+  });
+  process.once('beforeExit', () => {
+    kill(child);
+  });
 };


### PR DESCRIPTION
When the compiler or server errors `beforeExit` is never called, only `exit`. The handler in `beforeExit` can be used to extend the event loop so gracefully killing is possible, `exit` must give the death immediately.